### PR TITLE
add `repository` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "dependencies": {
     "@actions/core": "^1.2.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cschleiden/jest-github-actions-reporter"
+  },
   "devDependencies": {
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.8",


### PR DESCRIPTION
The package.json here is missing the `repository` property. as a result, the listing https://www.npmjs.com/package/jest-github-actions-reporter does not have a pointer back to this repo.

You may also want to add `homepage` and `bugs` entries